### PR TITLE
(DO NOT MERGE) Switch tracking to full Url tracking 

### DIFF
--- a/lib/withAnalytics.js
+++ b/lib/withAnalytics.js
@@ -49,14 +49,14 @@ var withAnalyticsCreator = function withAnalyticsCreator() {
       _createClass(WithAnalytics, [{
         key: 'componentDidMount',
         value: function componentDidMount() {
-          var page = this.props.location.pathname;
+          var page = this.props.location.url;
           (0, _utils.trackPage)('' + this.baseRoute + page);
         }
       }, {
         key: 'componentWillReceiveProps',
         value: function componentWillReceiveProps(nextProps) {
-          var currentPage = this.props.location.pathname;
-          var nextPage = nextProps.location.pathname;
+          var currentPage = this.props.location.url;
+          var nextPage = nextProps.location.url;
           if (currentPage !== nextPage) {
             (0, _utils.trackPage)('' + this.baseRoute + nextPage);
           }
@@ -71,7 +71,7 @@ var withAnalyticsCreator = function withAnalyticsCreator() {
       return WithAnalytics;
     }(_react2.default.PureComponent), _class.propTypes = {
       location: _propTypes2.default.shape({
-        pathname: _propTypes2.default.string.isRequired
+        url: _propTypes2.default.string.isRequired
       }).isRequired
     }, _temp2;
   };

--- a/src/withAnalytics.js
+++ b/src/withAnalytics.js
@@ -8,20 +8,20 @@ const withAnalyticsCreator = (options = {})  => Component =>
   class WithAnalytics extends React.PureComponent {
     static propTypes = {
       location: PropTypes.shape({
-        pathname: PropTypes.string.isRequired
+        url: PropTypes.string.isRequired
       }).isRequired
     };
     
     baseRoute = options.basename || '';
     
     componentDidMount() {
-      const page = this.props.location.pathname;
+      const page = this.props.location.url;
       trackPage(`${this.baseRoute}${page}`);
     }
 
     componentWillReceiveProps(nextProps) {
-      const currentPage = this.props.location.pathname;
-      const nextPage = nextProps.location.pathname;
+      const currentPage = this.props.location.url;
+      const nextPage = nextProps.location.url;
       if (currentPage !== nextPage) { 
         trackPage(`${this.baseRoute}${nextPage}`);
       }


### PR DESCRIPTION
This feature:

Allowing tracking for full url (including query parameters)
Currently not the most elegant solution, and technically breaking. I would prefer to enhance this configuration setup to include "withQueryParam" option (that could even default to true) that would handle the option of tracking query params.

Also, some talk of whether query param tracking is useful/duplicate of mixpanel or other services.